### PR TITLE
export Ucldebug so debugging can be disabled

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -37,9 +37,9 @@ import (
 // have their own order for items.
 const KeyOrder = "--ucl-keyorder--"
 
-var ucldebug bool = true
+var Ucldebug bool = true
 func debug(a... interface{}) {
-	if ucldebug {
+	if Ucldebug {
 		fmt.Println(a)
 	}
 }


### PR DESCRIPTION
Needed so that users of the library can disable debugging. Resubmitted without gofmt changes.
