### PR TITLE
Add toggle to suppress KeyOrder element in maps

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -37,6 +37,8 @@ import (
 // have their own order for items.
 const KeyOrder = "--ucl-keyorder--"
 
+var UclExportKeyOrder bool = true
+
 var Ucldebug bool = true
 func debug(a... interface{}) {
 	if Ucldebug {
@@ -307,7 +309,9 @@ restart:
 		} else {
 			// doesn't exist
 			korder = append(korder, k)
-			themap[KeyOrder] = korder
+			if UclExportKeyOrder {
+				themap[KeyOrder] = korder
+			}
 			themap[k] = res
 		}
 		if t.state == BRACECLOSE {

--- a/parser.go
+++ b/parser.go
@@ -37,6 +37,7 @@ import (
 // have their own order for items.
 const KeyOrder = "--ucl-keyorder--"
 
+// Allow to disable constructing the KeyOrder arrays
 var UclExportKeyOrder bool = true
 
 var Ucldebug bool = true
@@ -265,7 +266,10 @@ restart:
 		korder_intf, ok := themap[KeyOrder]
 		var korder []string
 		if !ok {
-			korder = make([]string, 0, 16)
+			if UclExportKeyOrder {
+				// only initialize if requested
+				korder = make([]string, 0, 16)
+			}
 		} else {
 			korder, ok = korder_intf.([]string)
 			if !ok {
@@ -308,8 +312,9 @@ restart:
 			}
 		} else {
 			// doesn't exist
-			korder = append(korder, k)
-			if UclExportKeyOrder {
+			if cap(korder) != 0 {
+				// only update KeyOrder if it was initialized
+				korder = append(korder, k)
 				themap[KeyOrder] = korder
 			}
 			themap[k] = res


### PR DESCRIPTION
Introduce UclExportKeyOrder variable that allows to
disable adding the KeyOrder element to maps.

This allows to avoid errors when encoding/json.Unmarshal
is used to convert the map[string]interface{} output to
struct and the struct contains a map[string]string element.
Otherwise the following error is returned:

  json: cannot unmarshal array into Go value of type string

The KeyOrder element is exported by default to preserve
behaviour.
